### PR TITLE
$::operatingsystem returned on Amazon AMIs in US east is 'Amazon', and in Ireland 'Linux'

### DIFF
--- a/manifests/infos.pp
+++ b/manifests/infos.pp
@@ -47,7 +47,7 @@ class puppi::infos {
   puppi::info { 'packages':
     description => 'Packages information' ,
     run         => $::operatingsystem ? {
-      /(?i:RedHat|CentOS|Scientific)/ => [ 'yum repolist' , 'rpm -qa' ] ,
+      /(?i:RedHat|CentOS|Scientific|Amazon|Linux)/ => [ 'yum repolist' , 'rpm -qa' ] ,
       /(?i:Debian|Ubuntu|Mint)/       => [ 'apt-config dump' , 'apt-cache stats' , 'apt-key list' , 'dpkg -l' ],
       /(Solaris)/                     => [ 'pkginfo' ],
       /(Archlinux)/                   => [ 'pacman -Qet' ],

--- a/manifests/logs.pp
+++ b/manifests/logs.pp
@@ -23,7 +23,7 @@ class puppi::logs {
       }
     }
 
-    RedHat,CentOS,Scientific: {
+    RedHat,CentOS,Scientific,Amazon,Linux: {
       puppi::log { 'system':
         description => 'General System Messages',
         log         => '/var/log/messages',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,11 +29,11 @@ class puppi::params  {
 # Directory where are placed the checks scripts
 # By default we use Nagios plugins
     $checkpluginsdir = $::operatingsystem ? {
-        /(?i:RedHat|CentOS|Scientific)/ => $::architecture ? {
+        /(?i:RedHat|CentOS|Scientific|Amazon|Linux)/ => $::architecture ? {
             x86_64  => '/usr/lib64/nagios/plugins',
             default => '/usr/lib/nagios/plugins',
         },
-        default                         => '/usr/lib/nagios/plugins',
+        default     => '/usr/lib/nagios/plugins',
     }
 
     $ntp = $ntp_server ? {
@@ -60,13 +60,13 @@ class puppi::params  {
 # Commands used in puppi info templates
 
     $info_package_query = $::operatingsystem ? {
-        /(?i:RedHat|CentOS|Scientific)/ => 'rpm -qi',
+        /(?i:RedHat|CentOS|Scientific|Amazon|Linux)/ => 'rpm -qi',
         /(?i:Ubuntu|Debian|Mint)/       => 'dpkg -s',
         default                         => 'echo',
     }
 
     $info_package_list = $::operatingsystem ? {
-        /(?i:RedHat|CentOS|Scientific)/ => 'rpm -ql',
+        /(?i:RedHat|CentOS|Scientific|Amazon|Linux)/ => 'rpm -ql',
         /(?i:Ubuntu|Debian|Mint)/       => 'dpkg -L',
         default                         => 'echo',
     }


### PR DESCRIPTION
$::operatingsystem returned on Amazon AMIs in US east is 'Amazon', and in Ireland 'Linux'. These are rebranded Centos 6 systems. Fix the detection of the operating system in order to correctly evaluate the architecture
