### PR TITLE
Add an Anchor['puppi::is_installed'] which marks the point where all Puppi files are installed

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -41,4 +41,6 @@ define puppi::check (
     tag     => 'puppi_check',
   }
 
+  Puppi::Check[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/checks.pp
+++ b/manifests/checks.pp
@@ -46,4 +46,6 @@ class puppi::checks {
     hostwide => 'yes' ,
   }
 
+  Class['puppi::checks'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -36,5 +36,7 @@ define puppi::deploy (
     tag     => 'puppi_deploy',
   }
 
+  Puppi::Deploy[$name] -> Anchor['puppi::is_installed']
+
 }
 

--- a/manifests/helper.pp
+++ b/manifests/helper.pp
@@ -26,4 +26,6 @@ define puppi::helper (
     content => template($template),
   }
 
+  Puppi::Helper[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/helpers.pp
+++ b/manifests/helpers.pp
@@ -13,4 +13,6 @@ class puppi::helpers {
     template => 'puppi/helpers/standard.yaml.erb',
   }
 
+  Class['puppi::helpers'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/info.pp
+++ b/manifests/info.pp
@@ -14,7 +14,7 @@
 #   description => "Network status and information" ,
 #   run  => [ "ifconfig" , "route -n" ],
 # }
-# 
+#
 # :include:../README.info
 #
 define puppi::info (
@@ -34,4 +34,7 @@ define puppi::info (
     content => template($templatefile),
     tag     => 'puppi_info',
   }
+
+  Puppi::Info[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/info/instance.pp
+++ b/manifests/info/instance.pp
@@ -29,4 +29,7 @@ define puppi::info::instance (
     content => template($templatefile),
     tag     => 'puppi_info',
   }
+
+  Puppi::Info::Instance[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/info/module.pp
+++ b/manifests/info/module.pp
@@ -55,4 +55,7 @@ define puppi::info::module (
     content => template($templatefile),
     tag     => 'puppi_info',
   }
+
+  Puppi::Info::Module[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/info/readme.pp
+++ b/manifests/info/readme.pp
@@ -62,4 +62,6 @@ define puppi::info::readme (
     }
   }
 
+  Puppi::Info::Readme[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/infos.pp
+++ b/manifests/infos.pp
@@ -66,4 +66,6 @@ class puppi::infos {
 #   run         => "ls -lR ${puppi::params::logdir}/puppi-data/",
   }
 
+  Class['puppi::infos'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class puppi {
     owner   => $puppi::params::configfile_owner,
     group   => $puppi::params::configfile_group,
     content => template('puppi/puppi.conf.erb'),
+    before  => Anchor['puppi::is_installed'],
     require => File['puppi_basedir'],
   }
 
@@ -29,6 +30,7 @@ class puppi {
     owner   => $puppi::params::configfile_owner,
     group   => $puppi::params::configfile_group,
     content => template('puppi/puppi.erb'),
+    before  => Anchor['puppi::is_installed'],
     require => File['puppi_basedir'],
   }
 
@@ -43,6 +45,7 @@ class puppi {
     recurse => true,
 #   purge   => true,
     ignore  => '.svn',
+    before  => Anchor['puppi::is_installed'],
     require => File['puppi_basedir'],
   }
 
@@ -59,4 +62,21 @@ class puppi {
 
   # Include prerequisits
   include puppi::prerequisites
-}
+
+  # This will create the Anchor['puppi::is_installed']
+  # which marks the point where all Puppi files are installed
+  # and before Puppi::Run
+  include puppi::is_installed
+
+}  # class puppi
+
+
+
+###################################################
+
+
+class puppi::is_installed {
+
+  anchor { 'puppi::is_installed': }
+
+}  # class puppi::is_installed

--- a/manifests/initialize.pp
+++ b/manifests/initialize.pp
@@ -34,5 +34,6 @@ define puppi::initialize (
     tag     => 'puppi_initialize',
   }
 
-}
+  Puppi::Initialize[$name] -> Anchor['puppi::is_installed']
 
+}

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -27,4 +27,7 @@ define puppi::log (
     content => template('puppi/log.erb'),
     tag     => 'puppi_log',
   }
+
+  Puppi::Log[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/logs.pp
+++ b/manifests/logs.pp
@@ -68,5 +68,7 @@ class puppi::logs {
 
   }
 
+  Class['puppi::logs'] -> Anchor['puppi::is_installed']
+
 }
 

--- a/manifests/mcollective/client.pp
+++ b/manifests/mcollective/client.pp
@@ -56,4 +56,6 @@ class puppi::mcollective::client {
     source  => 'puppet:///modules/puppi/mcollective/puppideploy',
   }
 
+  Class['puppi::mcollective::client'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/mcollective/server.pp
+++ b/manifests/mcollective/server.pp
@@ -29,4 +29,6 @@ class puppi::mcollective::server {
     source  => 'puppet:///modules/puppi/mcollective/puppi.rb',
   }
 
+  Class['puppi::mcollective::server'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/netinstall.pp
+++ b/manifests/netinstall.pp
@@ -1,6 +1,6 @@
 # Define: puppi::netinstall
 #
-# This defines simplifies the installation of a file 
+# This defines simplifies the installation of a file
 # downloaded from the web. It provides arguments to manage
 # different kind of downloads and custom commands.
 # It's used, among the others, by NextGen modules of webapps
@@ -8,16 +8,16 @@
 #
 # == Variables
 #
-# [*url*] 
+# [*url*]
 #   The Url of the file to retrieve. Required.
 #   Example: http://www.example42.com/file.tar.gz
 #
-# [*destination_dir*] 
-#   The final destination where to unpack or copy what has been 
+# [*destination_dir*]
+#   The final destination where to unpack or copy what has been
 #   downloaded. Required.
 #   Example: /var/www/html
 #
-# [*extracted_dir*] 
+# [*extracted_dir*]
 #   The name of the directory created after the extraction of the file
 #   Needed only if its name is different from the downloaded file name
 #   (without suffixes). Optional.
@@ -30,16 +30,16 @@
 #
 # [*work_dir*]
 #   A temporary work dir where file is downloaded. Default: /tmp
-# 
+#
 # [*extract_command*]
 #   The command used to extract the downloaded file.
 #   By default is autocalculated accoring to the file extension
 #   Set 'rsync' if the file has to be placed in the destination_dir
 #   as is (for example for war files)
-# 
+#
 # [*preextract_command*]
 #   An optional custom command to run before extracting the file.
-# 
+#
 # [*postextract_command*]
 #   An optional custom command to run after having extracted the file.
 #
@@ -132,6 +132,8 @@ define puppi::netinstall (
         path        => '/bin:/sbin:/usr/bin:/usr/sbin',
     }
   }
+
+  Puppi::Netinstall[$name] -> Anchor['puppi::is_installed']
 
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -95,4 +95,6 @@ class puppi::params  {
         default: { $general_base_source=$::base_source }
     }
 
+    Class['puppi::params'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -24,4 +24,6 @@ class puppi::prerequisites {
   # include nagios::plugins
   # include mailx
 
+  Class['puppi::prerequisites'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -91,4 +91,6 @@ define puppi::project (
       require => File["${puppi::params::projectsdir}/${name}"];
   }
 
+  Puppi::Project[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/report.pp
+++ b/manifests/report.pp
@@ -35,4 +35,6 @@ define puppi::report (
     tag     => 'puppi_report',
   }
 
+  Puppi::Report[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/rollback.pp
+++ b/manifests/rollback.pp
@@ -33,5 +33,7 @@ define puppi::rollback (
     tag     => 'puppi_rollback',
   }
 
+  Puppi::Rollback[$name] -> Anchor['puppi::is_installed']
+
 }
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -19,22 +19,11 @@ define puppi::run (
 
   require puppi::params
 
-  # This is a workaround to be avoid automatic puppi deploy at first Puppet run
-  # when we are not sure that the puppi deploy project has beed correctly
-  # setup.
-  # Sadly a better solution hasn't been found
-  exec { "Run_Puppi_${name}_FirstTimeLock":
-    command     => "touch ${puppi::params::archivedir}/puppirun_${name}_lock",
-    path        => '/bin:/sbin:/usr/sbin:/usr/bin',
-    refreshonly => true,
-  }
-
   exec { "Run_Puppi_${name}":
     command => "puppi deploy ${name} && touch ${puppi::params::archivedir}/puppirun_${name}",
     path    => '/bin:/sbin:/usr/sbin:/usr/bin',
-    onlyif  => "rm ${puppi::params::archivedir}/puppirun_${name}_lock",
     creates => "${puppi::params::archivedir}/puppirun_${name}",
-    before  => Exec["Run_Puppi_${name}_FirstTimeLock"],
+    require => Anchor['puppi::is_installed'],
   }
 
 }

--- a/manifests/skel.pp
+++ b/manifests/skel.pp
@@ -150,4 +150,6 @@ class puppi::skel {
     source  => 'puppet:///modules/puppi/mailpuppicheck',
   }
 
+  Class['puppi::skel'] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/todo.pp
+++ b/manifests/todo.pp
@@ -45,4 +45,7 @@ define puppi::todo (
     content => template('puppi/todo.erb'),
     tag     => 'puppi_todo',
   }
+
+  Puppi::Todo[$name] -> Anchor['puppi::is_installed']
+
 }

--- a/manifests/ze.pp
+++ b/manifests/ze.pp
@@ -26,4 +26,6 @@ define puppi::ze (
     content => inline_template('<%= variables.to_yaml %>'),
   }
 
+  Puppi::Ze[$name] -> Anchor['puppi::is_installed']
+
 }


### PR DESCRIPTION
Add an Anchor['puppi::is_installed'] which marks the point where all Puppi files are installed and before Puppi::Run. This works by having all classes or defines that deposit files to create a 'before' dependency with the anchor, and having Puppi::Run require this anchor.

Also removed the Puppi::Run first time lock thing. It never deployed my project automatically before i added all that
