### PR TITLE
feature added: deploy maven-snapshots

### DIFF
--- a/files/scripts/get_metadata.sh
+++ b/files/scripts/get_metadata.sh
@@ -14,6 +14,8 @@ showhelp () {
     echo "-mc <anotherstring> - The string to use as qualifier for Maven metadata config tars"
     echo "-mj <anotherstring> - The string to use as qualifier for Maven metadata jars"
     echo "-mw <anotherstring> - The string to use as qualifier for Maven metadata wars"
+    echo "-at <anotherstring> - The type to obtain the artifact, should be \"release\", "
+    echo "                      \"latest\" or \"snapshot\""
 }
 
 while [ $# -gt 0 ]; do
@@ -30,11 +32,28 @@ while [ $# -gt 0 ]; do
     -mw)
       war_suffix=$2
       shift 2 ;;
+    -at)
+      artifact_type=$2
+      shift 2 ;;
     -h)
       showhelp ;;
   esac
 done
 
+# validating input
+# see http://docs.codehaus.org/display/MAVEN/Repository+Metadata for specs
+case $artifact_type in
+    release)
+    ;;
+    latest)
+    ;;
+    snapshot)
+    ;;
+    *)
+    # defaulting to release for invalid arguments
+    artifact_type=release
+    ;;
+esac
 
 case $source_type in
     list)
@@ -49,7 +68,7 @@ case $source_type in
     tarball)
     ;;
     maven)
-    [ ${#version} -eq 0 ] && version=$(xml_parse release $downloadedfile )
+    [ ${#version} -eq 0 ] && version=$(xml_parse $artifact_type $downloadedfile )
     artifact=$(xml_parse artifactId $downloadedfile )
 
     # Definition of qualifiers for Maven has changed from the (wrong) assumption

--- a/manifests/project/maven.pp
+++ b/manifests/project/maven.pp
@@ -22,6 +22,11 @@
 # [*http_user*]
 #   The http_user to use for authentication to the source in case of http.
 #
+# [*artifact_type*]
+#   The artifact_type to parse the maven-metadata.xml. Either "release" or "latest"
+#   Default is "release". With artifactory, don't use the 
+#   "Maven Snapshot Version Behavior" "unique" for your repository.
+#
 # [*deploy_root*]
 #   The destination directory where file(s) are deployed.
 #
@@ -159,6 +164,7 @@ define puppi::project::maven (
   $source,
   $http_user                = '',
   $http_password            = '',
+  $artifact_type            = 'release',
   $deploy_root              = '',
   $user                     = 'root',
   $war_suffix               = 'suffixnotset',
@@ -289,7 +295,7 @@ define puppi::project::maven (
     puppi::deploy { "${name}-Extract_Maven_Metadata":
       priority  => '22' ,
       command   => 'get_metadata.sh' ,
-      arguments => "-m $document_suffix -mc $config_suffix -mj $jar_suffix -mw $war_suffix" ,
+      arguments => "-m $document_suffix -mc $config_suffix -mj $jar_suffix -mw $war_suffix -at $artifact_type" ,
       user      => 'root' ,
       project   => $name ,
       enable    => $enable ,


### PR DESCRIPTION
use it like this:

```
    puppi::project::maven { "myproject":
            source       => "http://artifactory.mycomp.com/repos/groupId/artifactId",
            http_user    => "test",            # maybe you need authentication
            http_password => "test",      
            artifact_type => "latest",        # choose "latest" instead of "release" (default)
            auto_deploy =>  "true",          # cool, with auto_deploy you have a continouos-
                                                        # deployment up and running :-)
            # [...]
    }
```
