### PR TITLE
rspec does not like select operation on the empty options hash

### DIFF
--- a/lib/puppet/parser/functions/options_lookup.rb
+++ b/lib/puppet/parser/functions/options_lookup.rb
@@ -41,7 +41,7 @@ EOS
     default_val = args[1]
     module_name = parent_module_name
     
-    value = lookupvar("#{module_name}::options").select{|k, v| k =~ /^#{option_name}$/ }.collect{ |k, v| "#{v}" }.to_s
+    value = lookupvar("#{module_name}::options").select{|k, v| k =~ /^#{option_name}$/ }.collect{ |k, v| "#{v}" }.to_s if (lookupvar("#{module_name}::options").size > 0)
     value = "#{default_val}" if (value == :undefined || value == '')
     
     return value


### PR DESCRIPTION
Detail: private method `select' called for "":String

I will be providing a rspec test case for this function soonish
