### PR TITLE
Fix user info when LANG is not C

### DIFF
--- a/manifests/infos.pp
+++ b/manifests/infos.pp
@@ -16,7 +16,7 @@ class puppi::infos {
     description => 'Users and logins information' ,
     run         => $::operatingsystem ? {
       Solaris => [ 'who' , 'last' ],
-      default => [ 'who' , 'last' , 'lastlog | grep -v \'Never logged in\'' ],
+      default => [ 'who' , 'last' , 'LANG=C lastlog | grep -v \'Never logged in\'' ],
     }
   }
 


### PR DESCRIPTION
The lastlog output can be translated, especially the "Never logged in" string (**Jamais connecté** in french).

The patch force LANG to be C, to fix this.
