### PR TITLE
In addition to module::params, params_lookup() will also have a look at self::params

### DIFF
--- a/lib/puppet/parser/functions/params_lookup.rb
+++ b/lib/puppet/parser/functions/params_lookup.rb
@@ -66,8 +66,9 @@ If no value is found in the defined sources, it returns an empty string ('')
     # Params class lookup for default value
     if loaded_classes.include?("#{module_name}::params"):
       value = lookupvar("::#{module_name}::params::#{var_name}")
+      return value if (not value.nil?) && (value != :undefined) && (value != '')
     end
 
-    return value
+    return ''
   end
 end


### PR DESCRIPTION
I have  two of these classes: bacula::director & bacula::client. Each with it's own ::params class. 
This addition makes sure the defaults values for bacula::director::params & bacula::client::params get found.

Additionally, it skips the lookup when bacula::params or bacula::*::params does not exist. So it suppresses these kind of warnings: `warning: Scope(Class[Bacula::Director]): Could not look up qualified variable '::bacula::params::package_name'; class ::bacula::params could not be found`
