### PR TITLE
Ruby 1.9: colon after "if" is not supported on ruby 1.9

### DIFF
--- a/lib/puppet/parser/functions/params_lookup.rb
+++ b/lib/puppet/parser/functions/params_lookup.rb
@@ -58,13 +58,13 @@ If no value is found in the defined sources, it returns an empty string ('')
     loaded_classes = catalog.classes
 
     # self::params class lookup for default value
-    if loaded_classes.include?("#{classname}::params"):
+    if loaded_classes.include?("#{classname}::params")
       value = lookupvar("::#{classname}::params::#{var_name}")
       return value if (not value.nil?) && (value != :undefined) && (value != '')
     end
 
     # Params class lookup for default value
-    if loaded_classes.include?("#{module_name}::params"):
+    if loaded_classes.include?("#{module_name}::params")
       value = lookupvar("::#{module_name}::params::#{var_name}")
       return value if (not value.nil?) && (value != :undefined) && (value != '')
     end


### PR DESCRIPTION
using a syntax supported by bot ruby 1.8 and ruby 1.9
