### PR TITLE
Added support for arrays

### DIFF
--- a/lib/puppet/parser/functions/options_lookup.rb
+++ b/lib/puppet/parser/functions/options_lookup.rb
@@ -41,7 +41,7 @@ EOS
     default_val = args[1]
     module_name = parent_module_name
     
-    value = lookupvar("#{module_name}::options").to_a.collect{|k, v| v if k == "#{option_name}" }.delete_if{|v| v == nil}[0] if (lookupvar("#{module_name}::options").size > 0)
+    value = lookupvar("#{module_name}::options")["#{option_name}"] if (lookupvar("#{module_name}::options").size > 0)
     value = "#{default_val}" if (value == :undefined || value == '' || value == nil)
     
     return value


### PR DESCRIPTION
It is now possible to specify an array as value to options

ie.

class { 'resolver':
  options => {
    nameserver => ['8.8.8.8', '8.8.4.4'],
  }
}
