### PR TITLE
new feature: reporting deployments into a mongodb

### DIFF
--- a/files/scripts/report_mongo.sh
+++ b/files/scripts/report_mongo.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# report_mongodb.sh - Made for Puppi
+# This script sends a summary to a mongodb defined in $1
+# e.g. somemongohost/dbname
+
+# Sources common header for Puppi scripts
+. $(dirname $0)/header || exit 10
+
+
+fqdn=$(facter fqdn)
+
+environment=$(facter environment -p)
+
+mongodb=$1
+result=$(grep result $logdir/$project/$tag/summary | awk '{ print $NF }')
+summary=$(cat $logdir/$project/$tag/summary)
+
+mcmd="db.deployments.insert({ts:new Date(),result:\"${result}\",fqdn:\"${fqdn}\",project:\"${project}\",source:\"${source}\",tag:\"${tag}\",version:\"${version}\",artifact:\"${artifact}\",testmode:\"${testmode}\",warfile:\"${warfile}\",environment:\"${environment}\"}); quit(0)"
+
+
+mongo $mongodb --eval "$mcmd"
+
+# Now do a reporting to enable "most-recent-versions on all servers"
+
+read -r -d '' mcmd <<'EOF'
+var map = function() {
+  project=this.project ;
+  emit( this.fqdn +":"+ this.project,  {project:this.project, fqdn:this.fqdn, ts:this.ts,version:this.version,environment:this.environment}  );
+};
+var reduce = function(k,vals) {
+  result = vals[0];
+  vals.forEach(function(val) { if (val.ts > result.ts) result=val } ) ;
+  return result;
+};
+db.deployments.mapReduce(
+  map,
+  reduce,
+  {out:{replace:"versions"}})
+EOF
+
+mongo $mongodb --eval "$mcmd"

--- a/manifests/project/maven.pp
+++ b/manifests/project/maven.pp
@@ -137,6 +137,10 @@
 #   (Optional) - The (space separated) email(s) to notify of deploy/rollback
 #   operations. If none is specified, no email is sent.
 #
+# [*report_mongo*]
+#   (Optional) - The mongodb in the report will be stored. Append the database
+#   with a slash ("mymongo.mydomain.com/theNameOfDb")
+#
 # [*backup_rsync_options*]
 #   (Optional) - The extra options to pass to rsync for backup operations. Use
 #   it, for example, to exclude directories that you don't want to archive.
@@ -196,6 +200,7 @@ define puppi::project::maven (
   $firewall_dst_port        = '0',
   $firewall_delay           = '1',
   $report_email             = '',
+  $report_mongo             = '',
   $backup_rsync_options     = '--exclude .snapshot',
   $backup_retention         = '5',
   $run_checks               = true,
@@ -727,6 +732,17 @@ define puppi::project::maven (
       priority  => '20' ,
       command   => 'report_mail.sh' ,
       arguments => $report_email ,
+      user      => 'root',
+      project   => $name ,
+      enable    => $enable ,
+    }
+  }
+  
+  if ($report_mongo != '') {
+    puppi::report { "${name}-Mongo_Store":
+      priority  => '30' ,
+      command   => 'report_mongo.sh' ,
+      arguments => $report_mongo ,
       user      => 'root',
       project   => $name ,
       enable    => $enable ,


### PR DESCRIPTION
Example configuration can be found in maven.pp.
A deployment will be stored in the mongodb in a collection called "deployments".
The most recent deployments for all servers will be calculated and stored
in a collection called "versions" (for ease of use in scripts ...)
