### PR TITLE
improved mcoll-agent especially the deploy-action

### DIFF
--- a/files/mcollective/puppi.rb
+++ b/files/mcollective/puppi.rb
@@ -13,42 +13,59 @@ module MCollective
 #                   validate :project, :shellsafe
                     project = request[:project] if request[:project]
                     reply.data = %x[puppi check #{project}].chomp
-#                    reply.exitcode = $?.exitstatus
+                    if ($?.exitstatus.int > 0)
+                      reply.fail "FAILED: #{reply.data}"
+                    end
             end
 
             def info_action
 #                   validate :project, :shellsafe
                     project = request[:project] if request[:project]
                     reply.data = %x[puppi info #{project}].chomp
-#                    reply.exitcode = $?.exitstatus
+                    if ($?.exitstatus.int > 0)
+                      reply.fail "FAILED: #{reply.data}"
+                    end
             end
 
             def log_action
 #                   validate :project, :shellsafe
                     project = request[:project] if request[:project]
                     reply.data = %x[puppi log #{project} -c 10].chomp
-#                    reply.exitcode = $?.exitstatus
+                    if ($?.exitstatus.int > 0)
+                      reply.fail "FAILED: #{reply.data}"
+                    end
             end
 
             def deploy_action
                     validate :project, :shellsafe
                     project = request[:project] if request[:project]
-                    reply.data = %x[puppi deploy #{project}].chomp
-#                    reply.exitcode = $?.exitstatus
+                    if (!File.directory? "/etc/puppi/projects/#{project}")
+                      reply.fail "No such project #{project}"
+                      return
+                    end
+                    puppioptions = request[:puppioptions]
+                    reply.data += %x[puppi deploy #{project} -o "#{puppioptions}"].chomp
+                    if ($?.exitstatus.int > 0)
+                      reply.fail "FAILED: #{reply.data}"
+                    end
             end
 
             def rollback_action
                     validate :project, :shellsafe
                     project = request[:project] if request[:project]
                     reply.data = %x[puppi rollback #{project} latest].chomp
-#                    reply.exitcode = $?.exitstatus
+                    if ($?.exitstatus.int > 0)
+                      reply.fail "FAILED: #{reply.data}"
+                    end
             end
 
             def init_action
                     validate :project, :shellsafe
                     project = request[:project] if request[:project]
                     reply.data = %x[puppi init #{project}].chomp
-#                    reply.exitcode = $?.exitstatus
+                    if ($?.exitstatus.int > 0)
+                      reply.fail "FAILED: #{reply.data}"
+                    end
             end
 
         end


### PR DESCRIPTION
If a project is not existing, it's better to fail properly. I have such a situation more often and right now the help-screen is printed out, which is not very helpful.

Also, the options are now supported.
