### PR TITLE
Error when using some urls with parameters and '&' character at bash, in...

### DIFF
--- a/manifests/project/war.pp
+++ b/manifests/project/war.pp
@@ -187,7 +187,7 @@ define puppi::project::war (
     puppi::initialize { "${name}-Deploy_Files":
       priority  => '40' ,
       command   => 'get_file.sh' ,
-      arguments => "-s ${init_source} -d ${deploy_root}" ,
+      arguments => "-s '${init_source}' -d '${deploy_root}'" ,
       user      => $user ,
       project   => $name ,
       enable    => $enable ,
@@ -211,7 +211,7 @@ define puppi::project::war (
     puppi::deploy { "${name}-Retrieve_WAR":
       priority  => '20' ,
       command   => 'get_file.sh' ,
-      arguments => "-s ${source} -a ${real_always_deploy}" ,
+      arguments => "-s '${source}' -a '${real_always_deploy}'" ,
       user      => 'root' ,
       project   => $name ,
       enable    => $enable ,
@@ -232,7 +232,7 @@ define puppi::project::war (
     puppi::deploy { "${name}-Backup_existing_WAR":
       priority  => '30' ,
       command   => 'archive.sh' ,
-      arguments => "-b ${deploy_root} -t war -s move -m diff -o '${backup_rsync_options}' -n ${backup_retention}" ,
+      arguments => "-b '${deploy_root}' -t war -s move -m diff -o '${backup_rsync_options}' -n '${backup_retention}'" ,
       user      => 'root' ,
       project   => $name ,
       enable    => $enable ,
@@ -243,7 +243,7 @@ define puppi::project::war (
     puppi::deploy { "${name}-Check_undeploy":
       priority  => '32' ,
       command   => 'checkwardir.sh' ,
-      arguments => "-a ${deploy_root}/${war_file}" ,
+      arguments => "-a '${deploy_root}/${war_file}'" ,
       user      => $user ,
       project   => $name ,
       enable    => $enable ,
@@ -287,7 +287,7 @@ define puppi::project::war (
     puppi::deploy { "${name}-Deploy_WAR":
       priority  => '40' ,
       command   => 'deploy_files.sh' ,
-      arguments => "-d ${deploy_root} -c ${bool_clean_deploy}",
+      arguments => "-d '${deploy_root}' -c '${bool_clean_deploy}'",
       user      => $user ,
       project   => $name ,
       enable    => $enable ,
@@ -330,7 +330,7 @@ define puppi::project::war (
     puppi::deploy { "${name}-Check_deploy":
       priority  => '45' ,
       command   => 'checkwardir.sh' ,
-      arguments => "-p ${deploy_root}/${war_file}" ,
+      arguments => "-p '${deploy_root}/${war_file}'" ,
       user      => $user ,
       project   => $name ,
       enable    => $enable ,
@@ -378,7 +378,7 @@ define puppi::project::war (
       puppi::rollback { "${name}-Remove_existing_WAR":
         priority  => '30' ,
         command   => 'delete.sh' ,
-        arguments => "${deploy_root}/${war_file}" ,
+        arguments => "'${deploy_root}/${war_file}'" ,
         user      => 'root' ,
         project   => $name ,
         enable    => $enable ,
@@ -388,7 +388,7 @@ define puppi::project::war (
       puppi::rollback { "${name}-Check_undeploy":
         priority  => '36' ,
         command   => 'checkwardir.sh' ,
-        arguments => "-a ${deploy_root}/${war_file}" ,
+        arguments => "-a '${deploy_root}/${war_file}'" ,
         user      => $user ,
         project   => $name ,
         enable    => $enable ,
@@ -431,7 +431,7 @@ define puppi::project::war (
       puppi::rollback { "${name}-Recover_Files_To_Deploy":
         priority  => '40' ,
         command   => 'archive.sh' ,
-        arguments => "-r ${deploy_root} -t war -o '${backup_rsync_options}'" ,
+        arguments => "-r '${deploy_root}' -t war -o '${backup_rsync_options}'" ,
         user      => $user ,
         project   => $name ,
         enable    => $enable ,
@@ -474,7 +474,7 @@ define puppi::project::war (
       puppi::rollback { "${name}-Check_deploy":
         priority  => '45' ,
         command   => 'checkwardir.sh' ,
-        arguments => "-p ${deploy_root}/${war_file}" ,
+        arguments => "-p '${deploy_root}/${war_file}'" ,
         user      => $user ,
         project   => $name ,
         enable    => $enable ,


### PR DESCRIPTION
Error when using some urls with parameters and '&' character at bash, in url example (http://domain.com/service/local/artifact/maven/content?r=private&g=com.myapp&a=my-app-catalog&v=5.31.3&p=war), if we do not use accents ', at the time of passing the url as parameter the scripts (eg get_file.sh), the bash interprets '&' character as (end of command, send command to backgroud). I tried to use these accents in the declaration of the manifesto, by calling the class puppi::project::war, however the manifests of puppi write scripts to deploy wrong.
