### PR TITLE
Changed action from config to configure to fix mcollective client

### DIFF
--- a/files/mcollective/mc-puppi
+++ b/files/mcollective/mc-puppi
@@ -20,7 +20,7 @@ options = rpcoptions do |parser, options|
     parser.separator "  log [topic] - Run puppi log. For all or specified topic"
     parser.separator "  todo - Run puppi todo"
     parser.separator "  deploy <project> - Run puppi deploy on the defined project"
-    parser.separator "  config <project> - Run puppi config on the defined project"
+    parser.separator "  configure <project> - Run puppi configure on the defined project"
     parser.separator "  rollback <project> - Run puppi rollback latest on the defined project"
     parser.separator "  init <project> - Run puppi init on the defined project"
 end
@@ -37,8 +37,8 @@ if ARGV.length >= 1
     project = ARGV.shift
     puppioptions = ARGV.shift
 
-    unless command =~ /^(check|deploy|rollback|init|config|info|log|todo)$/
-        puts("Command has to be check|info|log|deploy|rollback|init|config|todo")
+    unless command =~ /^(check|deploy|rollback|init|configure|info|log|todo)$/
+        puts("Command has to be check|info|log|deploy|rollback|init|configure|todo")
         exit 1
     end
 else

--- a/files/mcollective/puppi.ddl
+++ b/files/mcollective/puppi.ddl
@@ -36,7 +36,7 @@ metadata    :name        => "SimpleRPC Agent For PUPPI Commands",
     end
 end
 
-[ "deploy" , "rollback" , "init" , "config" ].each do |myact|
+[ "deploy" , "rollback" , "init" , "configure" ].each do |myact|
     action myact, :description => "Run puppi myact" do
         display :always
 

--- a/files/mcollective/puppi.rb
+++ b/files/mcollective/puppi.rb
@@ -68,10 +68,10 @@ module MCollective
                     end
             end
             
-            def config_action
+            def configure_action
                   validate :project, :shellsafe
                   project = request[:project] if request[:project]
-                  reply.data = %x[puppi config #{project}].chomp
+                  reply.data = %x[puppi configure #{project}].chomp
                   if ($?.exitstatus > 0)
                     reply.fail "FAILED: #{reply.data}"
                   end

--- a/templates/puppi.erb
+++ b/templates/puppi.erb
@@ -341,7 +341,7 @@ showhelp () {
    echo "info [topic] [-i] [-g <pattern>] - Show informations about the system"
    echo "todo - Show todo's checklist of the system"
    echo "init <project> [-i] [-f] [-t] - First time project initialization and setup"
-   echo "config <project> [-i] [-f] [-t] - Project configuration deployment."
+   echo "configure <project> [-i] [-f] [-t] - Project configuration deployment."
    echo "deploy <project> [-i] [-f] [-t] [-o ...] - Deploy the specified project"
    echo "rollback <project> [state] [-i] [-f] [-t] - Rollback the specified project. "
    echo " "
@@ -373,7 +373,7 @@ fi
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    deploy|init|config)
+    deploy|init|configure)
       report="yes"
       export action=$1
       if [ -n "$2" ] ; then
@@ -513,5 +513,5 @@ case $action in
     rollback) create_runtime_conf ; rollback ;;
     deploy) create_runtime_conf ; deploy ;;
     init) create_runtime_conf ; initialize ;;
-    config) create_runtime_conf ; configure ;;
+    configure) create_runtime_conf ; configure ;;
 esac


### PR DESCRIPTION
We had to rename the puppi config action to puppi configure, because we can't deploy with mcollective with the old solution. 

We don't found out, where the naming collision is happend, but after the renaming puppi is running with mcollective stable.
