### PR TITLE
Puppi requires Puppet Labs Stdlib Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The module provides:
 
 * Puppet defines to populate the output of the different actions
 
+This module requires functions provided by the [Puppet Labs Stdlib Module](https://github.com/puppetlabs/puppetlabs-stdlib).
+
 
 ## HOW TO INSTALL
 


### PR DESCRIPTION
Adding puppi to an otherwise empty manifest results in the following error:
```
Unknown function is_array at .../modules-0/puppi/manifests/info.pp:28
```
This is resolved by adding the Stdlib module.