### PR TITLE
Changed "source" to "packages" in minimal setup example.

### DIFF
--- a/manifests/install_packages.pp
+++ b/manifests/install_packages.pp
@@ -41,7 +41,7 @@
 #
 # - Minimal setup
 # puppi::install_packages { 'build_tools':
-#   source           => 'build-essential vim git-core curl bison',
+#   packages => 'build-essential vim git-core curl bison',
 # }
 #
 define puppi::install_packages (


### PR DESCRIPTION
Minimal setup example contained a reference to an invalid parameter.
