### PR TITLE
Bug with keep_gitdata

### DIFF
--- a/files/scripts/git.sh
+++ b/files/scripts/git.sh
@@ -158,7 +158,7 @@ do_install () {
     git checkout $verbosity $commit
   fi
 
-  if [ "x$gitdir" == "x$archivedir/$project-git" ] ; then
+  if [ "x$gitdir" == "x$archivedir/$project-git/gitrepo" ] ; then
     rsync -a --exclude=".git" $gitdir/$gitsubdir $deploy_root/
   fi
 


### PR DESCRIPTION
When `keep_gitdata` parameter is set to false, the project is not correctly deployed. This is because the project is cloned in `$archivedir/$project-git/gitrepo` and then rsynced to the `$deploy_root` directory. This is the right check in this case.
