### PR TITLE
When deleting old log dirs, preserve the main dir + project dir.

### DIFF
--- a/templates/puppi_clean.erb
+++ b/templates/puppi_clean.erb
@@ -7,4 +7,4 @@ if [ "<%= scope.lookupvar('puppi::params::logdir') %>" == "/" ] || [ "x<%= scope
   exit 1
 fi
 find "<%= scope.lookupvar('puppi::params::logdir') %>" -type f -mtime +<%= scope.lookupvar('puppi::logs_retention_days') %> -exec rm '{}' '+' >/dev/null 2>&1
-find "<%= scope.lookupvar('puppi::params::logdir') %>" -mindepth 1 -type d -mtime +<%= scope.lookupvar('puppi::logs_retention_days') %> -exec rmdir '{}' '+' >/dev/null 2>&1
+find "<%= scope.lookupvar('puppi::params::logdir') %>" -mindepth 2 -type d -mtime +<%= scope.lookupvar('puppi::logs_retention_days') %> -exec rmdir '{}' '+' >/dev/null 2>&1


### PR DESCRIPTION
We need *mindepth 2* to preserve the project folder within logdir.