### PR TITLE
Make params_lookup work with strict_variables, take 2

### DIFF
--- a/lib/puppet/parser/functions/params_lookup.rb
+++ b/lib/puppet/parser/functions/params_lookup.rb
@@ -47,12 +47,24 @@ If no value is found in the defined sources, it returns an empty string ('')
     end
 
     # Top Scope Variable Lookup (::modulename_varname)
-    value = lookupvar("::#{module_name}_#{var_name}")
+    catch (:undefined_variable) do
+      begin
+        value = lookupvar("::#{module_name}_#{var_name}")
+      rescue Puppet::ParseError => e
+        raise unless e.to_s =~ /^Undefined variable /
+      end
+    end
     return value if (not value.nil?) && (value != :undefined) && (value != '')
 
     # Look up ::varname (only if second argument is 'global')
     if arguments[1] == 'global'
-      value = lookupvar("::#{var_name}")
+      catch (:undefined_variable) do
+        begin
+          value = lookupvar("::#{var_name}")
+        rescue Puppet::ParseError => e
+          raise unless e.to_s =~ /^Undefined variable /
+        end
+      end
       return value if (not value.nil?) && (value != :undefined) && (value != '')
     end
 


### PR DESCRIPTION
We use catch for future parser and begin/rescue for current parser.

This is an enhanced version of c9798a08177c3bec513e67744397fd466c9401d9.