### PR TITLE
Fixing defaults for undefs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,11 +29,13 @@ class puppi::params  {
 
   $archivedir = $::puppi_archivedir ? {
     ''      => '/var/lib/puppi/archive',
+    undef   => '/var/lib/puppi/archive',
     default => $::puppi_archivedir,
   }
 
   $workdir = $::puppi_workdir ? {
     ''      => '/tmp/puppi',
+    undef   => '/tmp/puppi',
     default => $::puppi_workdir,
   }
 


### PR DESCRIPTION
Using puppet 3.7.5-1puppetlabs1, puppi was trying to use "puppi_workdir" (literal) as the `$::puppi_workdir` value.

With this small fix, it works as expected.