### PR TITLE
params_lookup future parser fix

### DIFF
--- a/lib/puppet/parser/functions/params_lookup.rb
+++ b/lib/puppet/parser/functions/params_lookup.rb
@@ -26,7 +26,7 @@ This fuction looks for the given variable name in a set of different sources:
 - ::modulename_varname
 - ::varname (if second argument is 'global')
 - ::modulename::params::varname
-If no value is found in the defined sources, it returns an empty string ('')
+If no value is found in the defined sources, it returns 'undef'.
     EOS
   ) do |arguments|
 
@@ -84,6 +84,7 @@ If no value is found in the defined sources, it returns an empty string ('')
       return value if (not value.nil?) && (value != :undefined) && (value != '')
     end
 
-    return ''
+
+    return
   end
 end


### PR DESCRIPTION
With future parser, the empty string is now true, not false.  Many
modules using params_lookup assume that it will return a false value if
it is unsuccessful.  This changes params_lookup to return undef instead
of an empty string when no value could be found.