### PR TITLE
use milliseconds in last_run

### DIFF
--- a/lib/facter/last_run.rb
+++ b/lib/facter/last_run.rb
@@ -2,6 +2,6 @@ require 'facter'
 Facter.add("last_run") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
   setcode do
-    Facter::Util::Resolution.exec('date')
+    Facter::Util::Resolution.exec("date '+%a %b %d %T:%N %Z %Y'")
   end
 end


### PR DESCRIPTION
The fact that the last_run fact only has second resolution can cause GC issues
for large-scale users of PuppetDB.

One drawback of the deduplication PuppetDB does for storage conservation is
that an orphan row is created every time two or more nodes that exclusively share a
fact value update that value at the same time. These orphans are deleted by the
periodic GC (period defined by gc-interval). Under normal circumstances,
creation of orphans is rare and the GC handles it fine. When last_run has
second-granularity though, this is guaranteed to happen at least onces every
time more than 60 nodes check in per minute. When well over 60 nodes are
checking in per minute it can become problematic. Changing last_run to include
milliseconds should eliminate the issue, since two nodes will never share the
same last_run fact.

See https://tickets.puppetlabs.com/browse/PDB-1124 for more discussion.

I have no idea whose code this may break, so caution is obviously warranted.