### PR TITLE
Fix bug in pull/clone for hg projects

### DIFF
--- a/files/scripts/hg.sh
+++ b/files/scripts/hg.sh
@@ -121,15 +121,18 @@ if [ "x$keep_hgdata" != "xtrue" ] ; then
 fi
 
 do_install () {
+  if [ "$branch" ]; then
+    $branch_param="--branch $branch"
+  fi
   if [ -d $hgdir/.hg ] ; then
     cd $hgdir
-    hg pull $verbosity origin $branch
+    hg pull $verbosity $branch_param
     hg update $verbosity $branch
     if [ "x$?" != "x0" ] ; then
       hg update $verbosity $branch
     fi
   else
-    hg clone $verbosity --branch $branch $source $hgdir
+    hg clone $verbosity $branch_param $source $hgdir
     cd $hgdir
   fi
 


### PR DESCRIPTION
There is no such thing as "origin" source repo in mercurial, so that line will fail.
The branch_param variable is needed because in pull/clone operations branches are specified in the --branch parameter, whereas in update operation they do not need the --branch part. 