### PR TITLE
Fix wrong var definition

### DIFF
--- a/files/scripts/hg.sh
+++ b/files/scripts/hg.sh
@@ -122,7 +122,7 @@ fi
 
 do_install () {
   if [ "$branch" ]; then
-    $branch_param="--branch $branch"
+    branch_param="--branch $branch"
   fi
   if [ -d $hgdir/.hg ] ; then
     cd $hgdir


### PR DESCRIPTION
Sorry, this is the correct changeset: former had a bug in bash var definition