### PR TITLE
Fix extras

### DIFF
--- a/manifests/extras.pp
+++ b/manifests/extras.pp
@@ -55,8 +55,8 @@ class puppi::extras {
 
   # Info Pages
   $network_run = $::operatingsystem ? {
-    Solaris => [ 'ifconfig -a' , 'netstat -nr' , 'cat /etc/resolv.conf' , 'arp -an' , 'netstat -na' ],
-    default => [ 'ifconfig' , 'route -n' , 'cat /etc/resolv.conf' , 'arp -an' , 'netstat -natup | grep LISTEN' ],
+    'Solaris' => [ 'ifconfig -a' , 'netstat -nr' , 'cat /etc/resolv.conf' , 'arp -an' , 'netstat -na' ],
+    default   => [ 'ifconfig' , 'route -n' , 'cat /etc/resolv.conf' , 'arp -an' , 'netstat -natup | grep LISTEN' ],
   }
 
   puppi::info { 'network':
@@ -65,8 +65,8 @@ class puppi::extras {
   }
 
   $users_run = $::operatingsystem ? {
-    Solaris => [ 'who' , 'last' ],
-    default => [ 'who' , 'last' , 'LANG=C lastlog | grep -v \'Never logged in\'' ],
+    'Solaris' => [ 'who' , 'last' ],
+    default   => [ 'who' , 'last' , 'LANG=C lastlog | grep -v \'Never logged in\'' ],
   }
 
   puppi::info { 'users':
@@ -75,8 +75,8 @@ class puppi::extras {
   }
 
   $perf_run = $::operatingsystem ? {
-    Solaris => [ 'uptime' , 'vmstat 1 5' ],
-    default => [ 'uptime' , 'free' , 'vmstat 1 5' ],
+    'Solaris' => [ 'uptime' , 'vmstat 1 5' ],
+    default   => [ 'uptime' , 'free' , 'vmstat 1 5' ],
   }
 
   puppi::info { 'perf':
@@ -85,8 +85,8 @@ class puppi::extras {
   }
 
   $disks_run = $::operatingsystem ? {
-    Solaris => [ 'df -h' , 'mount' ],
-    default => [ 'df -h' , 'mount' , 'blkid' , 'fdisk -l' ],
+    'Solaris' => [ 'df -h' , 'mount' ],
+    default   => [ 'df -h' , 'mount' , 'blkid' , 'fdisk -l' ],
   }
 
   puppi::info { 'disks':
@@ -95,8 +95,8 @@ class puppi::extras {
   }
 
   $hardware_run = $::operatingsystem ? {
-    Solaris => [ 'find /devices/' ],
-    default => [ 'lspci' , 'cat /proc/cpuinfo' ],
+    'Solaris' => [ 'find /devices/' ],
+    default   => [ 'lspci' , 'cat /proc/cpuinfo' ],
   }
 
   puppi::info { 'hardware':
@@ -130,7 +130,7 @@ class puppi::extras {
   ### Default Logs
   case $::operatingsystem {
 
-    Debian,Ubuntu: {
+    /Debian|Ubuntu/: {
       puppi::log { 'system':
         description => 'General System Messages',
         log         => ['/var/log/syslog'],
@@ -145,7 +145,7 @@ class puppi::extras {
       }
     }
 
-    RedHat,CentOS,Scientific,Amazon,Linux: {
+    /RedHat|CentOS|Scientific|Amazon|Linux/: {
       puppi::log { 'system':
         description => 'General System Messages',
         log         => ['/var/log/messages'],
@@ -160,7 +160,7 @@ class puppi::extras {
       }
     }
 
-    SLES,OpenSuSE: {
+    /SLES|OpenSuSE/: {
       puppi::log { 'system':
         description => 'General System Messages',
         log         => ['/var/log/messages'],
@@ -175,7 +175,7 @@ class puppi::extras {
       }
     }
 
-    Solaris: {
+    /Solaris/: {
       puppi::log { 'system':
         description => 'General System Messages',
         log         => ['/var/adm/messages'],
@@ -186,7 +186,7 @@ class puppi::extras {
       }
     }
 
-    Archlinux: {
+    /Archlinux/: {
       puppi::log { 'system':
         description => 'General System Messages',
         log         => ['/var/log/messages.log','/var/log/syslog.log'],

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -5,7 +5,21 @@
 # to to build up the commands list
 #
 define puppi::project (
-  $enable = true ) {
+  $deploy_root              = undef,
+  $source                   = undef,
+  $user                     = 'root',
+  $predeploy_customcommand  = '',
+  $postdeploy_customcommand = '',
+  $init_script              = '',
+  $disable_services         = '',
+  $firewall_src_ip          = '',
+  $firewall_dst_port        = 0,
+  $report_email             = '',
+  $files_prefix             = undef,
+  $source_baseurl           = undef,
+  $document_root            = '',
+  $config_root              = undef,
+  $enable                   = true ) {
 
   require puppi::params
 

--- a/manifests/project/archive.pp
+++ b/manifests/project/archive.pp
@@ -163,7 +163,16 @@ define puppi::project::archive (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      disable_services         => $disable_services,
+      firewall_src_port        => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable ,
     }
 
 ### DEPLOY SEQUENCE

--- a/manifests/project/builder.pp
+++ b/manifests/project/builder.pp
@@ -191,7 +191,18 @@ define puppi::project::builder (
   $source_filename = url_parse($source,'filename')
 
 # Create Project
-  puppi::project { $name: enable => $enable }
+  puppi::project { $name:
+    source                   => $source,
+    deploy_root              => $deploy_root,
+    user                     => $user,
+    predeploy_customcommand  => $predeploy_customcommand,
+    postdeploy_customcommand => $postdeploy_customcommand,
+    disable_services         => $disable_services,
+    firewall_src_ip          => $firewall_src_ip,
+    firewall_dst_port        => $firewall_dst_port,
+    report_email             => $report_email,
+    enable                   => $enable,
+  }
 
 
 ### INIT SEQUENCE

--- a/manifests/project/dir.pp
+++ b/manifests/project/dir.pp
@@ -145,7 +145,17 @@ define puppi::project::dir (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      init_script              => $init_script,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
     }
 
 

--- a/manifests/project/files.pp
+++ b/manifests/project/files.pp
@@ -161,7 +161,19 @@ define puppi::project::files (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      init_script              => $init_script,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable ,
+      files_prefix             => $files_prefix,
+      source_baseurl           => $source_baseurl,
     }
 
 

--- a/manifests/project/git.pp
+++ b/manifests/project/git.pp
@@ -180,7 +180,16 @@ define puppi::project::git (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      enable                   => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
     }
 
 

--- a/manifests/project/hg.pp
+++ b/manifests/project/hg.pp
@@ -174,7 +174,16 @@ define puppi::project::hg (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable ,
     }
 
 

--- a/manifests/project/maven.pp
+++ b/manifests/project/maven.pp
@@ -263,7 +263,19 @@ define puppi::project::maven (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      init_script              => $init_script,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
+      document_root            => $document_root,
+      config_root              => $config_root,
     }
 
 

--- a/manifests/project/mysql.pp
+++ b/manifests/project/mysql.pp
@@ -157,7 +157,16 @@ define puppi::project::mysql (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
     }
 
 

--- a/manifests/project/service.pp
+++ b/manifests/project/service.pp
@@ -112,7 +112,15 @@ define puppi::project::service (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      init_script              => $init_script,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
     }
 
 

--- a/manifests/project/svn.pp
+++ b/manifests/project/svn.pp
@@ -200,7 +200,16 @@ define puppi::project::svn (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
     }
 
 

--- a/manifests/project/tar.pp
+++ b/manifests/project/tar.pp
@@ -177,7 +177,17 @@ define puppi::project::tar (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      init_script              => $init_script,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
     }
 
 

--- a/manifests/project/war.pp
+++ b/manifests/project/war.pp
@@ -178,7 +178,17 @@ define puppi::project::war (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      init_script              => $init_script,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
     }
 
 

--- a/manifests/project/y4maven.pp
+++ b/manifests/project/y4maven.pp
@@ -244,7 +244,17 @@ define puppi::project::y4maven (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      source                   => $source,
+      deploy_root              => $deploy_root,
+      user                     => $user,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      init_script              => $init_script,
+      disable_services         => $disable_services,
+      report_email             => $report_email,
+      enable                   => $enable,
+      document_root            => $document_root,
+      config_root              => $config_root,
     }
 
 

--- a/manifests/project/yum.pp
+++ b/manifests/project/yum.pp
@@ -134,7 +134,13 @@ define puppi::project::yum (
 
 ### CREATE PROJECT
     puppi::project { $name:
-      enable => $enable ,
+      predeploy_customcommand  => $predeploy_customcommand,
+      postdeploy_customcommand => $postdeploy_customcommand,
+      disable_services         => $disable_services,
+      firewall_src_ip          => $firewall_src_ip,
+      firewall_dst_port        => $firewall_dst_port,
+      report_email             => $report_email,
+      enable                   => $enable,
     }
 
 ### DEPLOY SEQUENCE


### PR DESCRIPTION
I have made some changes for compatibilty with puppet 4:

- In ```extras.pp``` I have enclosed string comparators between ```'```
- In the template ```config.erb``` used from ```puppi::project``` variables/parameters from ```puppi::project::xxx``` defines can't be used. So I have added the variables used in the template as parameters for ```puppi::project```.