### PR TITLE
Fix pr 143

### DIFF
--- a/manifests/project/archive.pp
+++ b/manifests/project/archive.pp
@@ -169,7 +169,7 @@ define puppi::project::archive (
       predeploy_customcommand  => $predeploy_customcommand,
       postdeploy_customcommand => $postdeploy_customcommand,
       disable_services         => $disable_services,
-      firewall_src_port        => $firewall_src_ip,
+      firewall_src_ip          => $firewall_src_ip,
       firewall_dst_port        => $firewall_dst_port,
       report_email             => $report_email,
       enable                   => $enable ,


### PR DESCRIPTION
In [PR#143](https://github.com/example42/puppi/pull/143) I introduced an error calling ```puppi::project``` from ```puppi::project::archive```.
This PR fix that error.