### PR TITLE
Allow to use params_lookup in a subclass like params_lookup on puppet3

### DIFF
--- a/lib/puppet/functions/params_lookup.rb
+++ b/lib/puppet/functions/params_lookup.rb
@@ -55,9 +55,8 @@ Puppet::Functions.create_function(:params_lookup, Puppet::Functions::InternalFun
       return value if (not value.nil?) && (value != :undefined) && (value != '')
     end
 
-    # TODO: Set the correct classname when params_lookup used in subclasses
-    classname = modulename
-    # classname = scope.self.resource.name.downcase 
+    # Set the classname to first namespace when params_lookup used in subclasses
+    classname = scope.namespaces.first
 
     loaded_classes = closure_scope.catalog.classes
 


### PR DESCRIPTION
Patch for #148

Perhaps there is a better way, to check in these methods

```
| |!=
| |!~
| |<=>
| |==
| |===
| |=~
| |N_
| |Nn_
| |[]
| |[]=
| |_
| |__id__
| |__send__
| |adderrorcontext
| |alert
| |bound?
| |call_function
| |catalog
| |class
| |class_def
| |class_scope
| |class_set
| |clone
| |com
| |compiler
| |compiler=
| |crit
| |daemonize
| |debug
| |defaults
| |define_settings
| |define_singleton_method
| |devfail
| |display
| |dup
| |effective_symtable
| |emerg
| |enclosing_scope
| |enum_for
| |environment
| |ephemeral_from
| |ephemeral_level
| |eql?
| |equal?
| |err
| |error_context
| |exceptwrap
| |exist?
| |extend
| |fail
| |find_builtin_resource_type
| |find_defined_resource_type
| |find_definition
| |find_global_scope
| |find_hostclass
| |find_resource_type
| |findresource
| |freeze
| |frozen?
| |function_alert
| |function_any2array
| |function_any2bool
| |function_create_resources
| |function_crit
| |function_debug
| |function_deep_merge
| |function_defined_with_params
| |function_emerg
| |function_empty
| |function_ensure_packages
| |function_ensure_resource
| |function_err
| |function_fqdn_rand
| |function_fqdn_rotate
| |function_info
| |function_is_absolute_path
| |function_is_bool
| |function_is_hash
| |function_join
| |function_member
| |function_merge
| |function_notice
| |function_realize
| |function_str2bool
| |function_tagged
| |function_template
| |function_validate_absolute_path
| |function_validate_array
| |function_validate_bool
| |function_validate_hash
| |function_validate_integer
| |function_validate_re
| |function_validate_slength
| |function_validate_string
| |function_values_at
| |function_warning
| |handle_different_imports
| |handle_not_found
| |hash
| |include?
| |include_class
| |info
| |inherited_scope
| |initialize_clone
| |initialize_dup
| |inspect
| |instance_eval
| |instance_exec
| |instance_of?
| |instance_variable_defined?
| |instance_variable_get
| |instance_variable_set
| |instance_variables
| |is_a?
| |is_classscope?
| |is_nodescope?
| |is_topscope?
| |java
| |java_annotation
| |java_field
| |java_implements
| |java_kind_of?
| |java_name
| |java_package
| |java_require
| |java_signature
| |javafx
| |javax
| |kind_of?
| |lookup_as_local_name?
| |lookup_qualified_variable
| |lookupdefaults
| |lookuptype
| |lookupvar
| |meta_def
| |meta_eval
| |meta_undef
| |method
| |methods
| |n_
| |namespaces
| |new_ephemeral
| |new_match_scope
| |newscope
| |nil?
| |notice
| |ns_
| |object_id
| |org
| |parent
| |parent=
| |parent_module_name
| |pop_ephemerals
| |private_methods
| |protected_methods
| |psych_to_yaml
| |public_method
| |public_methods
| |public_send
| |push_ephemerals
| |real_function_alert
| |real_function_any2array
| |real_function_any2bool
| |real_function_create_resources
| |real_function_crit
| |real_function_debug
| |real_function_deep_merge
| |real_function_defined_with_params
| |real_function_emerg
| |real_function_empty
| |real_function_ensure_packages
| |real_function_ensure_resource
| |real_function_err
| |real_function_fqdn_rand
| |real_function_fqdn_rotate
| |real_function_info
| |real_function_is_absolute_path
| |real_function_is_bool
| |real_function_is_hash
| |real_function_join
| |real_function_member
| |real_function_merge
| |real_function_notice
| |real_function_realize
| |real_function_str2bool
| |real_function_tagged
| |real_function_template
| |real_function_validate_absolute_path
| |real_function_validate_array
| |real_function_validate_bool
| |real_function_validate_hash
| |real_function_validate_integer
| |real_function_validate_re
| |real_function_validate_slength
| |real_function_validate_string
| |real_function_values_at
| |real_function_warning
| |requiredopts
| |resolve_type_and_titles
| |resource
| |resource=
| |respond_to?
| |respond_to_missing?
| |s_
| |send
| |set_facts
| |set_match_data
| |set_options
| |set_server_facts
| |set_trusted
| |setvar
| |singleton_class
| |singleton_methods
| |source
| |source=
| |symbolize_options
| |tags
| |taint
| |tainted?
| |tap
| |to_enum
| |to_hash
| |to_java
| |to_json
| |to_pson
| |to_s
| |to_yaml
| |to_yaml_properties
| |transform_and_assert_classnames
| |trust
| |undef_as
| |unset_ephemeral_var
| |untaint
| |untrust
| |untrusted?
| |variable_not_found
| |warning
| |with_global_scope
| |with_guarded_scope
| |with_parameter_scope
| |without_ephemeral_scopes
```